### PR TITLE
ローカルでbackendサーバが起動しない問題を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,6 @@ down:
 shell:
 	docker-compose exec backend bash
 
-# backendコンテナの上でWebサーバを起動する
-.PHONY: server
-server:
-	docker-compose exec backend bash scripts/run_local_server.sh
-
 # すべてのコンテナとイメージを削除する
 .PHONY: delete-all
 delete-all:
@@ -26,7 +21,7 @@ delete-all:
 # テストを実行する
 .PHONY: test
 test:
-	docker-compose exec -T backend bash scripts/run_algorithm_tests.sh
+	docker-compose exec -T backend bash scripts/run_backend_tests.sh
 
 # キャッシュを削除してビルドする
 .PHONY: build

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -64,7 +64,7 @@ REST_FRAMEWORK = {
 }
 
 CORS_ORIGIN_WHITELIST = (
-    'algorithms-simulation.herokuapp.com',
+    'http://algorithms-simulation.herokuapp.com',
     'http://localhost:3000'
 )
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ django-heroku
 parameterized
 djangorestframework
 django-cors-headers
+pytest

--- a/backend/scripts/run_algorithm_tests.sh
+++ b/backend/scripts/run_algorithm_tests.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-python -m unittest discover test/algorithm

--- a/backend/scripts/run_backend_tests.sh
+++ b/backend/scripts/run_backend_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+python -m unittest discover test/algorithm
+pytest test/algsimulator/

--- a/backend/scripts/run_local_server.sh
+++ b/backend/scripts/run_local_server.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-python manage.py runserver 0:8000

--- a/backend/test/algsimulator/test_basic_requests.py
+++ b/backend/test/algsimulator/test_basic_requests.py
@@ -1,0 +1,9 @@
+import pytest
+import urllib.request
+
+BASE_URL = "http://localhost:8000"
+
+
+def test_sample():
+    # APIサーバが起動していることを確認
+    req = urllib.request.Request(BASE_URL)

--- a/backend/test/algsimulator/test_basic_requests.py
+++ b/backend/test/algsimulator/test_basic_requests.py
@@ -4,6 +4,7 @@ import urllib.request
 BASE_URL = "http://localhost:8000"
 
 
-def test_sample():
+def test_ping():
     # APIサーバが起動していることを確認
-    req = urllib.request.Request(BASE_URL)
+    with urllib.request.urlopen(BASE_URL) as response:
+        assert response.getcode() == 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./backend:/code
     ports:
       - '8000:8000'
-    command: tail -f /dev/null
+    command: python manage.py runserver 0:8000
   frontend:
     build:
       context: ./frontend


### PR DESCRIPTION
### 概要
* 主な修正点はdjangoの `CORS_ORIGIN_WHITELIST` に `http://` をつけたこと
* 元の事象が解消したことを確認するため、backendの機能テストを追加している
  * とりあえずbackendサーバをたたいて、ステータスコードが200であることだけ確認
* また、テストを書きやすくするため、backendコンテナ起動時にdjangoサーバを起動するよう改修を実施している

### 申し送り事項
* `CORS_ORIGIN_WHITELIST` 修正前の時点で機能テストが落ちることを確認
  * https://github.com/igarashi339/algorithms-simulation/runs/1941090328?check_suite_focus=true
 * 修正後、テストが通ることを確認
   * https://github.com/igarashi339/algorithms-simulation/runs/1941094709?check_suite_focus=true