### PR TITLE
Dijkstra法を実装(正常系のみ)

### DIFF
--- a/backend/algorithm/dijkstra.py
+++ b/backend/algorithm/dijkstra.py
@@ -5,7 +5,7 @@ import copy
 class Dijkstra:
     """ Dijkstra法による探索を実施するクラス """
     INVALID_NODE_INDEX = -1
-    INVALID_NODE_COST = -1
+    INVALID_LABEL = -1  # 適当に大きな値にする
 
     def __init__(self, graph):
         self.graph = copy.deepcopy(graph)
@@ -17,15 +17,15 @@ class Dijkstra:
         ただし、スタートノードからゴールノードまで到達不可能な場合はNoneを返す。
         """
         # コストが確定しているノードの集合
-        cost_fixed_nodes = [start_node]
+        cost_fixed_nodes = []
         # 各ノードのラベル
-        node_label_list = [Graph.INVALID_COST for i in range(self.graph.size())]
+        node_label_list = [Dijkstra.INVALID_LABEL for i in range(self.graph.size())]
         node_label_list[start_node] = 0
         # 最短経路における一つ前のノード
-        prev_node_dict = {start_node: -1}
+        prev_node_dict = {i: -1 for i in range(self.graph.size())}
         # dijkstra法シミュレーションオブジェクト
         dijkstra_simulation = DijkstraSimulation(graph_size=self.graph.size(),
-                                                 cost_matrix=self.graph.get_cost_matrix_str(),
+                                                 cost_matrix=self.graph.get_cost_matrix_list(),
                                                  start_node=start_node,
                                                  goal_node=goal_node)
         while goal_node not in cost_fixed_nodes:
@@ -33,15 +33,16 @@ class Dijkstra:
             if min_cost_node == Dijkstra.INVALID_NODE_INDEX:
                 # start_node から goal_node に到達不可能なので探索打ち切り
                 return None
+            cost_fixed_nodes.append(min_cost_node)
             # コストを確定したノードに隣接しているノードのコストを更新
             adjacent_nodes = self.get_all_adjacent_nodes(min_cost_node)
             for dst_node in adjacent_nodes:
                 if dst_node in cost_fixed_nodes:
                     continue
                 new_cost = node_label_list[min_cost_node] + self.graph.get_cost(min_cost_node, dst_node)
-            if new_cost < node_label_list[dst_node]:
-                prev_node_dict[dst_node] = min_cost_node
-                node_label_list[dst_node] = new_cost
+                if node_label_list[dst_node] == Dijkstra.INVALID_LABEL or new_cost < node_label_list[dst_node]:
+                    prev_node_dict[dst_node] = min_cost_node
+                    node_label_list[dst_node] = new_cost
             # シミュレーションオブジェクトを更新
             dijkstra_one_step = DijkstraOneStep(min_cost_node=min_cost_node,
                                                 cost_fixed_nodes=cost_fixed_nodes,
@@ -66,9 +67,9 @@ class Dijkstra:
                 continue
             target_cost = node_label_list[node_index]
             # ラベルが無効値の場合はスキップ
-            if target_cost == Graph.INVALID_COST:
+            if target_cost == Dijkstra.INVALID_LABEL:
                 continue
-            if min_cost < target_cost:
+            if target_cost < min_cost:
                 min_cost = target_cost
                 min_node_index = node_index
         return min_node_index
@@ -94,6 +95,7 @@ class Dijkstra:
         while prev_node_dict[target_node] != -1:
             target_node = prev_node_dict[target_node]
             shortest_path.append(target_node)
+        shortest_path.reverse()
         return shortest_path
 
     @staticmethod

--- a/backend/algorithm/dijkstra.py
+++ b/backend/algorithm/dijkstra.py
@@ -21,7 +21,7 @@ class Dijkstra:
         node_label_list = [Dijkstra.INVALID_LABEL for i in range(self.graph.size())]
         node_label_list[start_node] = 0
         # 最短経路における一つ前のノード
-        prev_node_dict = {i: -1 for i in range(self.graph.size())}
+        prev_node_dict = [-1 for i in range(self.graph.size())]
         # dijkstra法シミュレーションオブジェクト
         dijkstra_simulation = DijkstraSimulation(graph_size=self.graph.size(),
                                                  cost_matrix=self.graph.get_cost_matrix_list(),

--- a/backend/algorithm/dijkstra.py
+++ b/backend/algorithm/dijkstra.py
@@ -1,4 +1,5 @@
 from algorithm.models import Graph, DijkstraOneStep, DijkstraSimulation
+import copy
 
 
 class Dijkstra:
@@ -6,13 +7,94 @@ class Dijkstra:
     INVALID_NODE_INDEX = -1
     INVALID_NODE_COST = -1
 
-    @staticmethod
-    def calc_shortest_path(graph, start_node, goal_node):
+    def __init__(self, graph):
+        self.graph = copy.deepcopy(graph)
+
+    # todo: 単体テスト
+    def calc_shortest_path(self, start_node, goal_node):
         """
         Dijkstra法で最短経路を求める。
-        コスト最小ノードを保持するのに優先度つきキューを使用していないため、計算量はO(n^2)
+        ただし、スタートノードからゴールノードまで到達不可能な場合はNoneを返す。
         """
-        return Dijkstra.return_dummy_simulation_object()
+        # コストが確定しているノードの集合
+        cost_fixed_nodes = [start_node]
+        # 各ノードのラベル
+        node_label_list = [Graph.INVALID_COST for i in range(self.graph.size())]
+        node_label_list[start_node] = 0
+        # 最短経路における一つ前のノード
+        prev_node_dict = {start_node: -1}
+        # dijkstra法シミュレーションオブジェクト
+        dijkstra_simulation = DijkstraSimulation(graph_size=self.graph.size(),
+                                                 cost_matrix=self.graph.get_cost_matrix_str(),
+                                                 start_node=start_node,
+                                                 goal_node=goal_node)
+        while goal_node not in cost_fixed_nodes:
+            min_cost_node = self.find_min_cost_node(cost_fixed_nodes, node_label_list)
+            if min_cost_node == Dijkstra.INVALID_NODE_INDEX:
+                # start_node から goal_node に到達不可能なので探索打ち切り
+                return None
+            # コストを確定したノードに隣接しているノードのコストを更新
+            adjacent_nodes = self.get_all_adjacent_nodes(min_cost_node)
+            for dst_node in adjacent_nodes:
+                if dst_node in cost_fixed_nodes:
+                    continue
+                new_cost = node_label_list[min_cost_node] + self.graph.get_cost(min_cost_node, dst_node)
+            if new_cost < node_label_list[dst_node]:
+                prev_node_dict[dst_node] = min_cost_node
+                node_label_list[dst_node] = new_cost
+            # シミュレーションオブジェクトを更新
+            dijkstra_one_step = DijkstraOneStep(min_cost_node=min_cost_node,
+                                                cost_fixed_nodes=cost_fixed_nodes,
+                                                updated_labels=node_label_list,
+                                                updated_prev_node=prev_node_dict)
+            dijkstra_simulation.steps.append(dijkstra_one_step)
+        dijkstra_simulation.shortest_path_cost = node_label_list[goal_node]
+        dijkstra_simulation.shortest_path = Dijkstra.trace(prev_node_dict, start_node, goal_node)
+        return dijkstra_simulation
+
+    # todo: 単体テスト
+    def find_min_cost_node(self, cost_fixed_nodes, node_label_list):
+        """
+        コストが未確定のノードのうちラベルが最も小さいものを返す。
+        ただし、コストがInvalidのものしか残っていない場合はノード番号の無効値を返す。
+        """
+        min_node_index = Dijkstra.INVALID_NODE_INDEX
+        min_cost = max(node_label_list) + 1
+        for node_index in range(self.graph.size()):
+            # コストが確定している場合はスキップ
+            if node_index in cost_fixed_nodes:
+                continue
+            target_cost = node_label_list[node_index]
+            # ラベルが無効値の場合はスキップ
+            if target_cost == Graph.INVALID_COST:
+                continue
+            if min_cost < target_cost:
+                min_cost = target_cost
+                min_node_index = node_index
+        return min_node_index
+
+    # todo: 単体テスト
+    def get_all_adjacent_nodes(self, target_node):
+        """
+        target_nodeに隣接しているすべてのノードのリストを返す。
+        """
+        adjacent_nodes = []
+        for dst_node in range(self.graph.size()):
+            if self.graph.get_cost(target_node, dst_node) != Graph.INVALID_COST:
+                adjacent_nodes.append(dst_node)
+        return adjacent_nodes
+
+    # todo: 単体テスト
+    @staticmethod
+    def trace(prev_node_dict, start_node, goal_node):
+        """ 探索結果をもとにスタートノードからゴールノードまでのノード列を求める """
+        shortest_path = [goal_node]
+        target_node = goal_node
+        assert prev_node_dict[start_node] == -1
+        while prev_node_dict[target_node] != -1:
+            target_node = prev_node_dict[target_node]
+            shortest_path.append(target_node)
+        return shortest_path
 
     @staticmethod
     def return_dummy_simulation_object():

--- a/backend/algorithm/dijkstra.py
+++ b/backend/algorithm/dijkstra.py
@@ -10,7 +10,6 @@ class Dijkstra:
     def __init__(self, graph):
         self.graph = copy.deepcopy(graph)
 
-    # todo: 単体テスト
     def calc_shortest_path(self, start_node, goal_node):
         """
         Dijkstra法で最短経路を求める。
@@ -98,52 +97,3 @@ class Dijkstra:
         shortest_path.reverse()
         return shortest_path
 
-    @staticmethod
-    def return_dummy_simulation_object():
-        """
-        ダミーのシミュレーション結果を返す。
-        アルゴリズムが完成するまでのスタブとして用いる。
-        """
-        cost_matrix = [-1, 5, 8, -1, -1,
-                       -1, -1, 1, 3, 10,
-                       3, -1, -1, 4, 7,
-                       -1, 4, -1, -1, 5,
-                       -1, -1, -1, -1, -1]
-        steps = list()
-        steps.append(DijkstraOneStep(
-            min_cost_node=1,
-            cost_fixed_nodes=[1],
-            updated_labels={1: 0, 2: 5, 3: 8, 4: -1, 5: -1},
-            updated_prev_node={1: -1, 2: 1, 3: 1, 4: -1, 5: -1}
-        ))
-        steps.append(DijkstraOneStep(
-            min_cost_node=2,
-            cost_fixed_nodes=[1, 2],
-            updated_labels={1: 0, 2: 5, 3: 6, 4: 8, 5: 15},
-            updated_prev_node={1: -1, 2: 1, 3: 2, 4: 2, 5: 2}
-        ))
-        steps.append(DijkstraOneStep(
-            min_cost_node=3,
-            cost_fixed_nodes=[1, 2, 3],
-            updated_labels={1: 0, 2: 5, 3: 6, 4: 7, 5: 15},
-            updated_prev_node={1: -1, 2: 1, 3: 2, 4: 3, 5: 2}
-        ))
-        steps.append(DijkstraOneStep(
-            min_cost_node=4,
-            cost_fixed_nodes=[1, 2, 3, 4],
-            updated_labels={1: 0, 2: 5, 3: 6, 4: 7, 5: 12},
-            updated_prev_node={1: -1, 2: 1, 3: 2, 4: 3, 5: 4}
-        ))
-        steps.append(DijkstraOneStep(
-            min_cost_node=5,
-            cost_fixed_nodes=[1, 2, 3, 4, 5],
-            updated_labels={1: 0, 2: 5, 3: 6, 4: 7, 5: 12},
-            updated_prev_node={1: -1, 2: 1, 3: 2, 4: 3, 5: 4}
-        ))
-        return DijkstraSimulation(graph_size=5,
-                                  cost_matrix=cost_matrix,
-                                  start_node=1,
-                                  goal_node=5,
-                                  shortest_path=[1, 2, 3, 4, 5],
-                                  shortest_path_cost=12,
-                                  steps=steps)

--- a/backend/algorithm/models.py
+++ b/backend/algorithm/models.py
@@ -82,6 +82,7 @@ class DijkstraOneStep:
         # 更新後の「ひとつ前のノード」
         self.updated_prev_node = copy.deepcopy(updated_prev_node)
 
+    # todo: 単体テスト
     def equals(self, other):
         """ otherと自身が同じオブジェクトか判定する """
         if self.min_cost_node != other.min_cost_node:
@@ -115,6 +116,7 @@ class DijkstraSimulation:
         # Dijkstraのステップ(DijkstraOneStep)のリスト
         self.steps = copy.deepcopy(steps)
 
+    # todo: 単体テスト
     def equals(self, other):
         """
         otherと自身が同じオブジェクトかどうか判定する

--- a/backend/algorithm/models.py
+++ b/backend/algorithm/models.py
@@ -1,3 +1,6 @@
+import copy
+
+
 class Graph:
     INVALID_COST = -1
 
@@ -56,6 +59,15 @@ class Graph:
         """ ノード間のコストを返す。 """
         return self.__cost_matrix[node1][node2]
 
+    # todo: 単体テスト
+    def get_cost_matrix_str(self):
+        """ コスト行列を1次元文字列にして返す。 """
+        cost_matrix_str = ""
+        for i in range(self.__size):
+            for j in range(self.__size):
+                cost_matrix_str += str(self.__cost_matrix[i][j]) + " "
+        return cost_matrix_str.strip()
+
 
 class DijkstraOneStep:
     """ Dijkstra法の1ステップを表すクラス """
@@ -64,28 +76,51 @@ class DijkstraOneStep:
         # コスト最小のノード
         self.min_cost_node = min_cost_node
         # コストが確定しているノードの集合
-        self.cost_fixed_nodes = cost_fixed_nodes
+        self.cost_fixed_nodes = copy.deepcopy(cost_fixed_nodes)
         # 更新後の各ノードのラベル
-        self.updated_labels = updated_labels
+        self.updated_labels = copy.deepcopy(updated_labels)
         # 更新後の「ひとつ前のノード」
-        self.updated_prev_node = updated_prev_node
+        self.updated_prev_node = copy.deepcopy(updated_prev_node)
+
+    def equals(self, other):
+        """ otherと自身が同じオブジェクトか判定する """
+        return self.min_cost_node == other.min_cost_node and \
+            self.cost_fixed_nodes == other.cost_fixed_nodes and \
+            self.updated_labels == other.updated_labels and \
+            self.updated_prev_node == other.updated_prev_node
 
 
 class DijkstraSimulation:
     """ Dijkstra法のステップ集合を表すクラス """
 
-    def __init__(self, graph_size, cost_matrix, start_node, goal_node, shortest_path, shortest_path_cost, steps):
+    def __init__(self, graph_size, cost_matrix, start_node, goal_node,
+                 shortest_path=[], shortest_path_cost=-1, steps=[]):
         # グラフサイズ
         self.graph_size = graph_size
         # コスト行列(1次元)
-        self.cost_matrix = cost_matrix
+        self.cost_matrix = copy.deepcopy(cost_matrix)
         # スタートノード
         self.start_node = start_node
         # ゴールノード
         self.goal_node = goal_node
         # スタートノードからゴールノードまでの最短経路
-        self.shortest_path = shortest_path
+        self.shortest_path = copy.deepcopy(shortest_path)
         # 最短経路のコスト
         self.shortest_path_cost = shortest_path_cost
         # Dijkstraのステップ(DijkstraOneStep)のリスト
-        self.steps = steps
+        self.steps = copy.deepcopy(steps)
+
+    def equals(self, other):
+        """
+        otherと自身が同じオブジェクトかどうか判定する
+        """
+        for i, step in enumerate(self.steps):
+            other_step = other.steps[i]
+            if not step.equals(other_step):
+                return False
+        return self.graph_size == other.graph_size and \
+            self.cost_matrix == other.cost_matrix and \
+            self.start_node == other.start_node and \
+            self.goal_node == other.goal_node and \
+            self.shortest_path == other.shortest_path and \
+            self.shortest_path_cost == other.shortest_path_cost

--- a/backend/algorithm/models.py
+++ b/backend/algorithm/models.py
@@ -60,13 +60,13 @@ class Graph:
         return self.__cost_matrix[node1][node2]
 
     # todo: 単体テスト
-    def get_cost_matrix_str(self):
-        """ コスト行列を1次元文字列にして返す。 """
-        cost_matrix_str = ""
+    def get_cost_matrix_list(self):
+        """ コスト行列を1次元配列にして返す。 """
+        cost_matrix_list = []
         for i in range(self.__size):
             for j in range(self.__size):
-                cost_matrix_str += str(self.__cost_matrix[i][j]) + " "
-        return cost_matrix_str.strip()
+                cost_matrix_list.append(self.__cost_matrix[i][j])
+        return cost_matrix_list
 
 
 class DijkstraOneStep:
@@ -84,10 +84,15 @@ class DijkstraOneStep:
 
     def equals(self, other):
         """ otherと自身が同じオブジェクトか判定する """
-        return self.min_cost_node == other.min_cost_node and \
-            self.cost_fixed_nodes == other.cost_fixed_nodes and \
-            self.updated_labels == other.updated_labels and \
-            self.updated_prev_node == other.updated_prev_node
+        if self.min_cost_node != other.min_cost_node:
+            return False
+        if self.cost_fixed_nodes != other.cost_fixed_nodes:
+            return False
+        if self.updated_labels != other.updated_labels:
+            return False
+        if self.updated_prev_node != other.updated_prev_node:
+            return False
+        return True
 
 
 class DijkstraSimulation:

--- a/backend/algsimulator/views.py
+++ b/backend/algsimulator/views.py
@@ -16,7 +16,8 @@ def api_test(request):
 def dijkstra(request):
     """ Dijkstra法の探索結果を返す(ダミー実装)"""
     graph = Graph("hoge")
-    sim_obj = Dijkstra.calc_shortest_path(graph, int("1"), int("5"))
+    dijkstra = Dijkstra(graph)
+    sim_obj = dijkstra.calc_shortest_path(int("1"), int("5"))
     json_str = {
         "status": "OK",
         "search_info": sim_obj

--- a/backend/algsimulator/views.py
+++ b/backend/algsimulator/views.py
@@ -15,9 +15,12 @@ def api_test(request):
 
 def dijkstra(request):
     """ Dijkstra法の探索結果を返す(ダミー実装)"""
-    graph = Graph("hoge")
+    start_node = 0
+    goal_node = 4
+    cost_matrix = "5 -1 5 8 -1 -1 -1 -1 1 3 10 3 -1 -1 1 7 -1 4 -1 -1 5 -1 -1 -1 -1 -1"
+    graph = Graph(cost_matrix)
     dijkstra = Dijkstra(graph)
-    sim_obj = dijkstra.calc_shortest_path(int("1"), int("5"))
+    sim_obj = dijkstra.calc_shortest_path(start_node, goal_node)
     json_str = {
         "status": "OK",
         "search_info": sim_obj

--- a/backend/test/algorithm/test_dijkstra.py
+++ b/backend/test/algorithm/test_dijkstra.py
@@ -1,0 +1,66 @@
+import unittest
+from algorithm.models import Graph, DijkstraSimulation, DijkstraOneStep
+from algorithm.dijkstra import Dijkstra
+from parameterized import parameterized
+
+
+class TestDijkstra(unittest.TestCase):
+    def test_calc_shortest_path(self):
+        graph = Graph("5 -1 5 8 -1 -1 -1 -1 1 3 10 3 -1 -1 4 7 -1 4 -1 -1 5 -1 -1 -1 -1 -1")
+        assert graph.is_valid()
+        dijkstra = Dijkstra(graph)
+        start_node = 0
+        goal_node = 4
+        dijkstra_simulation = dijkstra.calc_shortest_path(start_node, goal_node)
+        expect_dijkstra_simulation = TestDijkstra.get_expect_result1()
+        assert dijkstra_simulation.equals(expect_dijkstra_simulation)
+
+    @staticmethod
+    def get_expect_result1():
+        cost_matrix = [-1, 5, 8, -1, -1,
+                       -1, -1, 1, 3, 10,
+                       3, -1, -1, 4, 7,
+                       -1, 4, -1, -1, 5,
+                       -1, -1, -1, -1, -1]
+        steps = list()
+        steps.append(DijkstraOneStep(
+            min_cost_node=0,
+            cost_fixed_nodes=[0],
+            updated_labels={0: 0, 1: 5, 2: 8, 3: -1, 4: -1},
+            updated_prev_node={1: -1, 2: 0, 3: 0, 4: -1, 5: -1}
+        ))
+        steps.append(DijkstraOneStep(
+            min_cost_node=1,
+            cost_fixed_nodes=[0, 1],
+            updated_labels={0: 0, 1: 5, 2: 6, 3: 8, 4: 15},
+            updated_prev_node={1: -1, 2: 0, 3: 1, 4: 1, 5: 1}
+        ))
+        steps.append(DijkstraOneStep(
+            min_cost_node=2,
+            cost_fixed_nodes=[0, 1, 2],
+            updated_labels={0: 0, 1: 5, 2: 6, 3: 7, 4: 15},
+            updated_prev_node={1: -1, 2: 0, 3: 1, 4: 2, 5: 1}
+        ))
+        steps.append(DijkstraOneStep(
+            min_cost_node=3,
+            cost_fixed_nodes=[0, 1, 2, 3],
+            updated_labels={0: 0, 1: 5, 2: 6, 3: 7, 4: 12},
+            updated_prev_node={0: -1, 1: 0, 2: 1, 3: 2, 4: 3}
+        ))
+        steps.append(DijkstraOneStep(
+            min_cost_node=4,
+            cost_fixed_nodes=[0, 1, 2, 3, 4],
+            updated_labels={0: 0, 1: 5, 2: 6, 3: 7, 4: 12},
+            updated_prev_node={0: -1, 1: 0, 2: 1, 3: 2, 4: 3}
+        ))
+        return DijkstraSimulation(graph_size=5,
+                                  cost_matrix=cost_matrix,
+                                  start_node=0,
+                                  goal_node=4,
+                                  shortest_path=[0, 1, 2, 3, 4],
+                                  shortest_path_cost=12,
+                                  steps=steps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/test/algorithm/test_dijkstra.py
+++ b/backend/test/algorithm/test_dijkstra.py
@@ -27,31 +27,31 @@ class TestDijkstra(unittest.TestCase):
             min_cost_node=0,
             cost_fixed_nodes=[0],
             updated_labels=[0, 5, 8, -1, -1],
-            updated_prev_node={0: -1, 1: 0, 2: 0, 3: -1, 4: -1}
+            updated_prev_node=[-1, 0, 0, -1, -1]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=1,
             cost_fixed_nodes=[0, 1],
             updated_labels=[0, 5, 6, 8, 15],
-            updated_prev_node={0: -1, 1: 0, 2: 1, 3: 1, 4: 1}
+            updated_prev_node=[-1, 0, 1, 1, 1]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=2,
             cost_fixed_nodes=[0, 1, 2],
             updated_labels=[0, 5, 6, 7, 13],
-            updated_prev_node={0: -1, 1: 0, 2: 1, 3: 2, 4: 2}
+            updated_prev_node=[-1, 0, 1, 2, 2]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=3,
             cost_fixed_nodes=[0, 1, 2, 3],
             updated_labels=[0, 5, 6, 7, 12],
-            updated_prev_node={0: -1, 1: 0, 2: 1, 3: 2, 4: 3}
+            updated_prev_node=[-1, 0, 1, 2, 3]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=4,
             cost_fixed_nodes=[0, 1, 2, 3, 4],
             updated_labels=[0, 5, 6, 7, 12],
-            updated_prev_node={0: -1, 1: 0, 2: 1, 3: 2, 4: 3}
+            updated_prev_node=[-1, 0, 1, 2, 3]
         ))
         return DijkstraSimulation(graph_size=5,
                                   cost_matrix=cost_matrix,

--- a/backend/test/algorithm/test_dijkstra.py
+++ b/backend/test/algorithm/test_dijkstra.py
@@ -6,7 +6,7 @@ from parameterized import parameterized
 
 class TestDijkstra(unittest.TestCase):
     def test_calc_shortest_path(self):
-        graph = Graph("5 -1 5 8 -1 -1 -1 -1 1 3 10 3 -1 -1 4 7 -1 4 -1 -1 5 -1 -1 -1 -1 -1")
+        graph = Graph("5 -1 5 8 -1 -1 -1 -1 1 3 10 3 -1 -1 1 7 -1 4 -1 -1 5 -1 -1 -1 -1 -1")
         assert graph.is_valid()
         dijkstra = Dijkstra(graph)
         start_node = 0
@@ -19,38 +19,38 @@ class TestDijkstra(unittest.TestCase):
     def get_expect_result1():
         cost_matrix = [-1, 5, 8, -1, -1,
                        -1, -1, 1, 3, 10,
-                       3, -1, -1, 4, 7,
+                       3, -1, -1, 1, 7,
                        -1, 4, -1, -1, 5,
                        -1, -1, -1, -1, -1]
         steps = list()
         steps.append(DijkstraOneStep(
             min_cost_node=0,
             cost_fixed_nodes=[0],
-            updated_labels={0: 0, 1: 5, 2: 8, 3: -1, 4: -1},
-            updated_prev_node={1: -1, 2: 0, 3: 0, 4: -1, 5: -1}
+            updated_labels=[0, 5, 8, -1, -1],
+            updated_prev_node={0: -1, 1: 0, 2: 0, 3: -1, 4: -1}
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=1,
             cost_fixed_nodes=[0, 1],
-            updated_labels={0: 0, 1: 5, 2: 6, 3: 8, 4: 15},
-            updated_prev_node={1: -1, 2: 0, 3: 1, 4: 1, 5: 1}
+            updated_labels=[0, 5, 6, 8, 15],
+            updated_prev_node={0: -1, 1: 0, 2: 1, 3: 1, 4: 1}
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=2,
             cost_fixed_nodes=[0, 1, 2],
-            updated_labels={0: 0, 1: 5, 2: 6, 3: 7, 4: 15},
-            updated_prev_node={1: -1, 2: 0, 3: 1, 4: 2, 5: 1}
+            updated_labels=[0, 5, 6, 7, 13],
+            updated_prev_node={0: -1, 1: 0, 2: 1, 3: 2, 4: 2}
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=3,
             cost_fixed_nodes=[0, 1, 2, 3],
-            updated_labels={0: 0, 1: 5, 2: 6, 3: 7, 4: 12},
+            updated_labels=[0, 5, 6, 7, 12],
             updated_prev_node={0: -1, 1: 0, 2: 1, 3: 2, 4: 3}
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=4,
             cost_fixed_nodes=[0, 1, 2, 3, 4],
-            updated_labels={0: 0, 1: 5, 2: 6, 3: 7, 4: 12},
+            updated_labels=[0, 5, 6, 7, 12],
             updated_prev_node={0: -1, 1: 0, 2: 1, 3: 2, 4: 3}
         ))
         return DijkstraSimulation(graph_size=5,


### PR DESCRIPTION
### 概要
* タイトルのとおり
* これまで通り、`/dijkstra` をたたくとダミーの経路探索結果が返却される
  * これまでは内部でべた書きしてあったjsonをそのまま返却していたが、実際に経路探索を走らせるようにした

### 申し送り事項
* テストについては一番大きい粒度(APIテスト)のテストのみ実装し通過することを確認している
  * 個々のメソッドの単体テストについては追って追加する方針(todoコメントを残している)

### レビュ観点
* テストケース(`TestDijkstra#test_calc_shortest_path`)に不備がないか
* 内部ロジックをざっと眺めて、違和感のあるところはないか
* メソッドや変数の命名や構成に違和感がないか