### PR TITLE
テストが失敗した際にGithub Actionsで検知できるようにする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: make up
-      - run: make test
+      - run: make backend-unit-test
+      - run: make backend-function-test

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,18 @@ delete-all:
 # テストを実行する
 .PHONY: test
 test:
-	docker-compose exec -T backend bash scripts/run_backend_tests.sh
+	make backend-unit-test
+	make backend-function-test
+
+# backendの単体テストを実行する
+.PHONY: backend-unit-test
+backend-unit-test:
+	docker-compose exec -T backend bash scripts/run_unit_test.sh
+
+# backendの機能テストを実行する
+.PHONY: backend-function-test
+backend-function-test:
+	docker-compose exec -T backend bash scripts/run_function_test.sh
 
 # キャッシュを削除してビルドする
 .PHONY: build

--- a/backend/algsimulator/error_code.py
+++ b/backend/algsimulator/error_code.py
@@ -14,6 +14,7 @@ class ErrorCode(Enum):
     UE4 = auto()  # start_node がグラフ中に存在しない
     UE5 = auto()  # goal_node がグラフ中に存在しない
     UE6 = auto()  # スタートからゴールに到達できない
+    UE7 = auto()  # スタートノードとゴールノードが一致
 
     @staticmethod
     def get_message(e):
@@ -37,3 +38,5 @@ class ErrorCode(Enum):
             return "goal_node is not exist in the graph."
         if e == ErrorCode.UE6:
             return "There is no path in the graph from start_node to goal_node."
+        if e == ErrorCode.UE7:
+            return "start_node and goal_node are the same."

--- a/backend/algsimulator/views.py
+++ b/backend/algsimulator/views.py
@@ -42,6 +42,8 @@ def dijkstra(request):
         return http_error_response(ErrorCode.UE4)
     if goal_node < 0 or graph.size() <= goal_node:
         return http_error_response(ErrorCode.UE5)
+    if start_node == goal_node:
+        return http_error_response(ErrorCode.UE7)
     dijkstra = Dijkstra(graph)
     sim_obj = dijkstra.calc_shortest_path(start_node, goal_node)
     if not sim_obj:

--- a/backend/scripts/run_backend_tests.sh
+++ b/backend/scripts/run_backend_tests.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-python -m unittest discover test/algorithm
-pytest test/algsimulator/

--- a/backend/scripts/run_function_test.sh
+++ b/backend/scripts/run_function_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pytest test/algsimulator/

--- a/backend/scripts/run_unit_test.sh
+++ b/backend/scripts/run_unit_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python -m unittest discover test/algorithm

--- a/backend/test/algorithm/test_dijkstra.py
+++ b/backend/test/algorithm/test_dijkstra.py
@@ -1,6 +1,7 @@
 import unittest
 from algorithm.models import Graph, DijkstraSimulation, DijkstraOneStep
 from algorithm.dijkstra import Dijkstra
+from parameterized import parameterized
 
 
 class TestDijkstra(unittest.TestCase):

--- a/backend/test/algsimulator/test_dijkstra.py
+++ b/backend/test/algsimulator/test_dijkstra.py
@@ -1,6 +1,5 @@
 import json
 import urllib.request
-from parameterized import parameterized
 
 BASE_URL = "http://localhost:8000/dijkstra/"
 
@@ -11,9 +10,6 @@ class TestDijkstra:
         self.headers = {
             "Content-Type": "application/json"
         }
-        self.start_node = 0
-        self.goal_node = 0
-        self.cost_matrix = "5 -1 5 8 -1 -1 -1 -1 1 3 10 3 -1 -1 1 7 -1 4 -1 -1 5 -1 -1 -1 -1 -1"
         self.body = {
             "start_node": 0,
             "goal_node": 4,
@@ -170,3 +166,18 @@ class TestDijkstra:
             assert data_json["status"] == "NG"
             assert data_json["error_code"] == "ErrorCode.UE6"
 
+    def test_start_and_goal_are_the_same(self):
+        """
+        異常系：スタートノードとゴールノードが一致している場合はエラーになることを確認
+        """
+        self.body = {
+            "start_node": 0,
+            "goal_node": 0,
+            "cost_matrix": "5 -1 5 8 -1 -1 -1 -1 1 3 10 3 -1 -1 1 7 -1 4 -1 -1 5 -1 -1 -1 -1 -1"
+        }
+        with urllib.request.urlopen(self.get_response()) as response:
+            assert response.getcode() == 200
+            data_str = response.read().decode()
+            data_json = json.loads(data_str)
+            assert data_json["status"] == "NG"
+            assert data_json["error_code"] == "ErrorCode.UE7"


### PR DESCRIPTION
### 概要
* テストが失敗してもGithub Actionsで成功になるという事象が発生していたため修正
  * https://github.com/igarashi339/algorithms-simulation/pull/42

### 検証事項
* テストの失敗を正しく検知できることを確認
  * https://github.com/igarashi339/algorithms-simulation/runs/2048904775?check_suite_focus=true
* コードを修正し、テストが通るようになることを確認
  * https://github.com/igarashi339/algorithms-simulation/actions/runs/628662708