### PR TITLE
独自ドメインからAPIサーバにアクセスできるようにする

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -66,7 +66,7 @@ REST_FRAMEWORK = {
 
 CORS_ORIGIN_WHITELIST = (
     'https://algorithms-simulation.herokuapp.com',
-    "algsim.net",
+    "https://algsim.net",
     'http://localhost:3000'
 )
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -28,6 +28,7 @@ DEBUG = False
 ALLOWED_HOSTS = [
     "algorithms-simulation.herokuapp.com",
     "algorithms-simulation-api.herokuapp.com",
+    "algsim.net",
     "localhost",
 ]
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -66,6 +66,7 @@ REST_FRAMEWORK = {
 
 CORS_ORIGIN_WHITELIST = (
     'https://algorithms-simulation.herokuapp.com',
+    "algsim.net",
     'http://localhost:3000'
 )
 


### PR DESCRIPTION
### 概要
* 独自ドメイン(algsim.net)を追加した際の対応もれ
  * APIサーバ(Django)の CORS_ORIGIN_WHITELIST に独自ドメインを追加

### 検証
* https://algsim.net でシミュレーションを実施ボタンを押して結果が返ってくることを確認