### PR TITLE
dijkstra法のシミュレーションオブジェクトへの情報追加

### DIFF
--- a/backend/algorithm/dijkstra.py
+++ b/backend/algorithm/dijkstra.py
@@ -44,6 +44,7 @@ class Dijkstra:
                     node_label_list[dst_node] = new_cost
             # シミュレーションオブジェクトを更新
             dijkstra_one_step = DijkstraOneStep(min_cost_node=min_cost_node,
+                                                adjacent_nodes=adjacent_nodes,
                                                 cost_fixed_nodes=cost_fixed_nodes,
                                                 updated_labels=node_label_list,
                                                 updated_prev_node=prev_node_dict)

--- a/backend/algorithm/models.py
+++ b/backend/algorithm/models.py
@@ -72,9 +72,11 @@ class Graph:
 class DijkstraOneStep:
     """ Dijkstra法の1ステップを表すクラス """
 
-    def __init__(self, min_cost_node, cost_fixed_nodes, updated_labels, updated_prev_node):
+    def __init__(self, min_cost_node, adjacent_nodes, cost_fixed_nodes, updated_labels, updated_prev_node):
         # コスト最小のノード
         self.min_cost_node = min_cost_node
+        # コスト最小のノードに隣接しているノード
+        self.adjacent_nodes = adjacent_nodes
         # コストが確定しているノードの集合
         self.cost_fixed_nodes = copy.deepcopy(cost_fixed_nodes)
         # 更新後の各ノードのラベル

--- a/backend/test/algorithm/test_dijkstra.py
+++ b/backend/test/algorithm/test_dijkstra.py
@@ -28,30 +28,35 @@ class TestDijkstra(unittest.TestCase):
         steps = list()
         steps.append(DijkstraOneStep(
             min_cost_node=0,
+            adjacent_nodes=[1, 2],
             cost_fixed_nodes=[0],
             updated_labels=[0, 5, 8, -1, -1],
             updated_prev_node=[-1, 0, 0, -1, -1]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=1,
+            adjacent_nodes=[2, 3, 4],
             cost_fixed_nodes=[0, 1],
             updated_labels=[0, 5, 6, 8, 15],
             updated_prev_node=[-1, 0, 1, 1, 1]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=2,
+            adjacent_nodes=[0, 3, 4],
             cost_fixed_nodes=[0, 1, 2],
             updated_labels=[0, 5, 6, 7, 13],
             updated_prev_node=[-1, 0, 1, 2, 2]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=3,
+            adjacent_nodes=[1, 4],
             cost_fixed_nodes=[0, 1, 2, 3],
             updated_labels=[0, 5, 6, 7, 12],
             updated_prev_node=[-1, 0, 1, 2, 3]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=4,
+            adjacent_nodes=[],
             cost_fixed_nodes=[0, 1, 2, 3, 4],
             updated_labels=[0, 5, 6, 7, 12],
             updated_prev_node=[-1, 0, 1, 2, 3]


### PR DESCRIPTION
### 概要
* dijkstra法の各ステップにおける、コスト最小ノードの隣接ノード（＝ラベル更新対象ノード）の集合を返却するように改修
  * https://coins-dawn.slack.com/archives/C01LEHXSS9H/p1615298528002100

### 検証
* テストを追加しパスすることを確認