### PR TITLE
ノード数の入力フィールドを分ける

### DIFF
--- a/frontend/react-app/src/dijkstra/inputs.js
+++ b/frontend/react-app/src/dijkstra/inputs.js
@@ -12,8 +12,14 @@ export const dijkstraInputs = [
     type: 'number'
   },
   {
+    key: 'nodeNum',
+    value: '5',
+    label: 'ノード数',
+    type: 'number'
+  },
+  {
     key: 'costMatrix',
-    value: '5 -1 5 8 -1 -1 -1 -1 1 3 10 3 -1 -1 1 7 -1 4 -1 -1 5 -1 -1 -1 -1 -1',
+    value: '-1 5 8 -1 -1 -1 -1 1 3 10 3 -1 -1 1 7 -1 4 -1 -1 5 -1 -1 -1 -1 -1',
     label: 'コスト行列',
     type: 'string'
   }

--- a/frontend/react-app/src/util.js
+++ b/frontend/react-app/src/util.js
@@ -21,7 +21,16 @@ export const createRequestBody = (arr) => {
   const obj = result.reduce((acc, cur) => {
     return assoc(cur.key, cur.value, acc)
   }, {})
+  
+  // 入力フィールドの値を結合
+  const fixedObj = ((obj) => {
+    return {
+      'startNode': obj.startNode,
+      'goalNode': obj.goalNode,
+      'costMatrix': obj.nodeNum + " " + obj.costMatrix
+    }
+  })(obj)
 
   // スネークケースに変換
-  return toSnakeCaseObject(obj)
+  return toSnakeCaseObject(fixedObj)
 }


### PR DESCRIPTION
※このPRの向き先は `main` ではなく `dijkstra-unittest` になっているので注意

### 概要
* ノード数の入力フィールドを分離
![キャプチャ](https://user-images.githubusercontent.com/33785163/111902750-3f75d300-8a82-11eb-8354-fe07a37cc8f2.PNG)

### 検証
* シミュレーション実行ボタンを押下し、問題なく実行できることを確認