### PR TITLE
テーブルを彩色

### DIFF
--- a/backend/algorithm/dijkstra.py
+++ b/backend/algorithm/dijkstra.py
@@ -35,16 +35,18 @@ class Dijkstra:
             cost_fixed_nodes.append(min_cost_node)
             # コストを確定したノードに隣接しているノードのコストを更新
             adjacent_nodes = self.get_all_adjacent_nodes(min_cost_node)
+            adjacent_cost_unfixed_nodes = []
             for dst_node in adjacent_nodes:
                 if dst_node in cost_fixed_nodes:
                     continue
+                adjacent_cost_unfixed_nodes.append(dst_node)
                 new_cost = node_label_list[min_cost_node] + self.graph.get_cost(min_cost_node, dst_node)
                 if node_label_list[dst_node] == Dijkstra.INVALID_LABEL or new_cost < node_label_list[dst_node]:
                     prev_node_dict[dst_node] = min_cost_node
                     node_label_list[dst_node] = new_cost
             # シミュレーションオブジェクトを更新
             dijkstra_one_step = DijkstraOneStep(min_cost_node=min_cost_node,
-                                                adjacent_nodes=adjacent_nodes,
+                                                adjacent_nodes=adjacent_cost_unfixed_nodes,
                                                 cost_fixed_nodes=cost_fixed_nodes,
                                                 updated_labels=node_label_list,
                                                 updated_prev_node=prev_node_dict)

--- a/backend/test/algorithm/test_dijkstra.py
+++ b/backend/test/algorithm/test_dijkstra.py
@@ -42,14 +42,14 @@ class TestDijkstra(unittest.TestCase):
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=2,
-            adjacent_nodes=[0, 3, 4],
+            adjacent_nodes=[3, 4],
             cost_fixed_nodes=[0, 1, 2],
             updated_labels=[0, 5, 6, 7, 13],
             updated_prev_node=[-1, 0, 1, 2, 2]
         ))
         steps.append(DijkstraOneStep(
             min_cost_node=3,
-            adjacent_nodes=[1, 4],
+            adjacent_nodes=[4],
             cost_fixed_nodes=[0, 1, 2, 3],
             updated_labels=[0, 5, 6, 7, 12],
             updated_prev_node=[-1, 0, 1, 2, 3]

--- a/frontend/react-app/src/dijkstra/DijkstraTable.jsx
+++ b/frontend/react-app/src/dijkstra/DijkstraTable.jsx
@@ -21,7 +21,7 @@ export const DijkstraTable = ({ steps }) => {
       </TableHead>
       <TableBody>
         {steps.map((row, index) => (
-          <TableRow key={index}>
+          <TableRow key={index} bgcolor={row.color}>
             <TableCell className={classes.cell}>{row.id}</TableCell>
             <TableCell className={classes.cell}>{row.fixed ? 'TRUE' : 'FALSE'}</TableCell>
             <TableCell className={classes.cell}>{row.label === -1 ? "∞" : row.label}</TableCell>

--- a/frontend/react-app/src/dijkstra/dijkstra.js
+++ b/frontend/react-app/src/dijkstra/dijkstra.js
@@ -75,6 +75,7 @@ const makeNodeColoredGraphs = (response, graph)  => {
   const shortestPathColor = 'salmon'
   const startNodeColor = 'red'
   const goalNodeColor = 'red'
+  const costFixedNodeColor = 'gray'
 
   const updateGraph = (nodeId, color) => (graph) => {
     const updatedNode = assoc('color', {background: color} , graph.nodes[nodeId])
@@ -84,13 +85,22 @@ const makeNodeColoredGraphs = (response, graph)  => {
 
   const steps = response.data.search_info.steps;
   const coloredGraphs = steps.reduce((acc, cur) => {
+    // コスト確定済ノードの色を更新
+    const costFixedNodeColoredGraph = cur.cost_fixed_nodes.reduce((acc, cur) => {
+      return updateGraph(cur, costFixedNodeColor)(acc)
+    }, graph)
     // コスト最小ノードの色を更新
-    const mincostNodeColoredGraph = updateGraph(cur.min_cost_node, minCostNodeColor)(graph)
+    const mincostNodeColoredGraph = updateGraph(cur.min_cost_node, minCostNodeColor)(costFixedNodeColoredGraph)
     acc.push(mincostNodeColoredGraph)
+
+    // コスト確定済ノードの色を更新
+    const costFixedNodeColoredGraph2 = cur.cost_fixed_nodes.reduce((acc, cur) => {
+      return updateGraph(cur, costFixedNodeColor)(acc)
+    }, graph)
     // ラベル更新対象ノードの色を更新
     const labelUpdateNodeColoredGraph = cur.adjacent_nodes.reduce((acc, cur) => {
       return updateGraph(cur, labelUpdateNodeColor)(acc)
-    }, graph)
+    }, costFixedNodeColoredGraph2)
     acc.push(labelUpdateNodeColoredGraph)
     return acc
   }, [graph])

--- a/frontend/react-app/src/dijkstra/dijkstra.test.js
+++ b/frontend/react-app/src/dijkstra/dijkstra.test.js
@@ -71,7 +71,7 @@ test.each(
     [1, 2, "white"],
     [1, 3, "white"],
     [1, 4, "white"],
-    [2, 0, "white"],
+    [2, 0, "yellow"],
     [2, 1, "lightgreen"],
     [2, 2, "lightgreen"],
     [2, 3, "white"],
@@ -142,6 +142,28 @@ test.each(
     expect(targetRow.fixed).toBe(fixed)
     expect(targetRow.label).toBe(label)
     expect(targetRow.prevNode).toBe(prevNode)
+  }
+)
+
+test.each(
+  [
+    [1, 0, "yellow"],
+    [2, 0, "yellow"],
+    [2, 1, "lightgreen"],
+    [2, 2, "lightgreen"],
+    [3, 0, "yellow"],
+    [3, 1, "yellow"],
+    [4, 0, "yellow"],
+    [4, 1, "yellow"],
+    [4, 2, "lightgreen"],
+    [4, 3, "lightgreen"],
+    [4, 4, "lightgreen"],
+  ]
+)(
+  "tableColorTest: step=%i, node=%i, color=%s", (step, nodeId, color) => {
+    const table = tables[step]
+    const tableRow = table.find(row => row.id === nodeId)
+    expect(tableRow.color).toBe(color)
   }
 )
 


### PR DESCRIPTION
本プルリクの向き先はmainではないため注意。

### 概要
* ノードと同じ色でテーブルを彩色した
  * コストが確定済のノード色はグレーがよいという話を事前にしていたが、分かりづらいためyellowにしている
  * 色については簡単に変更できるようになっているので、配色についての異論があれば別途対応する 
![キャプチャ](https://user-images.githubusercontent.com/33785163/112742711-d800db80-8fcb-11eb-8a68-5ccda90a0cbd.PNG)
* このプルリクで、バックエンドAPIの仕様が若干変更されているため注意
  * これまでは `adjacent_nodes` に「ラベル最小ノードに隣接する **すべて** のノード」が格納されていた
  * コスト確定済ノードについては、ラベル最小ノードに隣接していたとしてもラベル更新対象にはならない
    * 緑色で着色するのはふさわしくないため、`adjacent_nodes` に詰めないように変更した